### PR TITLE
fix(image-thumbnails): [TD-221] show broken thumbnail when image fails to load

### DIFF
--- a/lib/postprocess/image.js
+++ b/lib/postprocess/image.js
@@ -91,15 +91,19 @@ module.exports = async files => {
           'base64'
         )
       } else {
-        const response = await limit(() => axios({
-          url: imageConfig.src,
-          responseType: 'arraybuffer',
-          method: 'GET'
-        }))
-        const contentType =
-          response.headers['content-type'] || response.headers['Content-Type']
-        imageExtensions = contentType.split('/')[1]
-        imageBuffer = Buffer.from(response.data)
+        try {
+          const response = await limit(() => axios({
+            url: imageConfig.src,
+            responseType: 'arraybuffer',
+            method: 'GET'
+          }))
+          const contentType =
+            response.headers['content-type'] || response.headers['Content-Type']
+          imageExtensions = contentType.split('/')[1]
+          imageBuffer = Buffer.from(response.data)
+        } catch (err) {
+          console.warn('Failed to read image', { imageConfig }, { err });
+        }
       }
 
       // check if the file is valid

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsreport-docx",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "jsreport recipe rendering docx files",
   "homepage": "https://github.com/jsreport/jsreport-docx",
   "repository": {


### PR DESCRIPTION
**JIRA**
https://capmo-team.atlassian.net/browse/TD-221

**Summary**
When an image fails to be downloaded, the report generation fails. We will now not fail the report, but show the broken thumbnail image.