### PR TITLE
fix(img): [TD-1265] fix case image url doesnt return content type

### DIFF
--- a/lib/postprocess/image.js
+++ b/lib/postprocess/image.js
@@ -98,7 +98,7 @@ module.exports = async files => {
             method: 'GET'
           }))
           const contentType =
-            response.headers['content-type'] || response.headers['Content-Type']
+            response.headers['content-type'] || response.headers['Content-Type'] || 'image/png'
           imageExtensions = contentType.split('/')[1]
           imageBuffer = Buffer.from(response.data)
         } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsreport-docx",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsreport-docx",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "jsreport recipe rendering docx files",
   "homepage": "https://github.com/jsreport/jsreport-docx",
   "repository": {


### PR DESCRIPTION
**JIRA**
https://capmo-team.atlassian.net/browse/TD-1265

**Summary**
When image url doesn't return content-type, we will now fallback to PNG as content type. If this is not correct, the image will still not be rendered correctly.
The edge case here is that plan service urls did not return content-type for their images which are always png. That will be fix separately.