### PR TITLE
fix: [WE-4313  repair duplicate rIds in jsreport-docx output so Libre…

### DIFF
--- a/lib/postprocess/image.js
+++ b/lib/postprocess/image.js
@@ -5,7 +5,7 @@ const path = require('path')
 const fs = require('fs')
 
 const stringReplaceAsync = require('string-replace-async')
-const { nodeListToArray, pxToEMU, cmToEMU } = require('../utils')
+const { nodeListToArray, pxToEMU, cmToEMU, allocateFreshRid } = require('../utils')
 const { DOMParser, XMLSerializer } = require('xmldom')
 
 const getDimension = value => {
@@ -118,8 +118,10 @@ module.exports = async files => {
       const relsElements = nodeListToArray(
         relsDoc.getElementsByTagName('Relationship')
       )
-      const relsCount = relsElements.length
-      const id = relsCount + 1
+      // Allocate an rId that does not collide with any existing relationship.
+      // See utils.allocateFreshRid for the LibreOffice-vs-Word interaction
+      // that motivates this lookup instead of a naive `relsCount + 1`.
+      const id = allocateFreshRid(relsElements)
       const relEl = relsDoc.createElement('Relationship')
       relEl.setAttribute('Id', `rId${id}`)
       relEl.setAttribute(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -30,3 +30,43 @@ module.exports.cmToEMU = (val) => {
 }
 
 module.exports.serializeXml = (doc) => new XMLSerializer().serializeToString(doc).replace(/xmlns(:[a-z0-9]+)?="" ?/g, '')
+
+/**
+ * Returns a fresh rId number that does not collide with any existing
+ * `Id="rIdN"` in the supplied list of <Relationship> elements.
+ *
+ * The previous logic in postprocess/image.js used `relsCount + 1`, which
+ * collided whenever the rels file already contained non-sequential rIds. For
+ * example a template carrying 21 relationships whose ids reach up to rId23
+ * would receive a new rId22 that conflicts with the existing rId22. Microsoft
+ * Word tolerates duplicate `Id` attributes (it picks the relationship whose
+ * Type matches the consumer context), but the OOXML spec requires Ids to be
+ * unique and stricter consumers do not. In particular LibreOffice — which is
+ * frequently used to convert DOCX to PDF (e.g. via Gotenberg) — resolves
+ * `<a:blip r:embed="rId22">` to the *first* declaration of rId22 in the rels
+ * file. When that first declaration is not an image (often it is a font
+ * table, theme, or header part), LibreOffice silently drops the image during
+ * PDF rendering while still emitting the rest of the document, leaving users
+ * with mysteriously image-less PDFs that look fine in Word.
+ *
+ * The allocator below preserves the historical starting point (`relsCount + 1`)
+ * to keep media filenames stable for templates that never collided, then
+ * advances past any rId already in use.
+ *
+ * @param {Array} relsElements - existing <Relationship> elements (any order)
+ * @returns {number} a numeric rId suffix that is not yet used in the document
+ */
+module.exports.allocateFreshRid = (relsElements) => {
+  const used = new Set()
+  for (let i = 0; i < relsElements.length; i++) {
+    const id = relsElements[i].getAttribute('Id')
+    if (id) {
+      used.add(id)
+    }
+  }
+  let n = relsElements.length + 1
+  while (used.has(`rId${n}`)) {
+    n += 1
+  }
+  return n
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsreport-docx",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsreport-docx",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "jsreport recipe rendering docx files",
   "homepage": "https://github.com/jsreport/jsreport-docx",
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -1733,3 +1733,69 @@ describe('docx with extensions.docx.previewInWordOnline === false', () => {
     result.content.toString().should.not.containEql('iframe')
   })
 })
+
+describe('utils.allocateFreshRid', () => {
+  const { DOMParser } = require('xmldom')
+  const { nodeListToArray, allocateFreshRid } = require('../lib/utils')
+
+  const buildRels = (ids) => {
+    const xml =
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+      '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+      ids
+        .map(
+          (id) =>
+            `<Relationship Id="${id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/${id}.png"/>`
+        )
+        .join('') +
+      '</Relationships>'
+    const doc = new DOMParser().parseFromString(xml)
+    return nodeListToArray(doc.getElementsByTagName('Relationship'))
+  }
+
+  it('returns relsCount + 1 when no collision exists', () => {
+    const rels = buildRels(['rId1', 'rId2', 'rId3'])
+    allocateFreshRid(rels).should.be.eql(4)
+  })
+
+  it('skips an rId that would collide with an existing non-sequential id', () => {
+    // Template rels reach up to rId23 but the count is only 21, so the
+    // legacy "relsCount + 1" allocator would reuse rId22 and rId23.
+    const rels = buildRels([
+      'rId1', 'rId2', 'rId3', 'rId4', 'rId5', 'rId6', 'rId7', 'rId8',
+      'rId9', 'rId10', 'rId11', 'rId12', 'rId13', 'rId14', 'rId15',
+      'rId16', 'rId17', 'rId18', 'rId19', 'rId22', 'rId23'
+    ])
+    allocateFreshRid(rels).should.be.eql(24)
+  })
+
+  it('keeps advancing past consecutive collisions', () => {
+    const rels = buildRels(['rId1', 'rId2', 'rId3', 'rId4', 'rId5'])
+    allocateFreshRid(rels).should.be.eql(6)
+
+    const ridsWithRunOfCollisions = buildRels([
+      'rId1', 'rId4', 'rId5', 'rId6', 'rId7'
+    ])
+    // relsCount = 5, starts at 6, 6 and 7 are taken → returns 8
+    allocateFreshRid(ridsWithRunOfCollisions).should.be.eql(8)
+  })
+
+  it('handles an empty rels list', () => {
+    allocateFreshRid(buildRels([])).should.be.eql(1)
+  })
+
+  it('ignores relationships missing an Id attribute', () => {
+    // xmldom's getAttribute returns '' for missing attributes; the helper
+    // must not treat that as a real collision against the empty string.
+    const xml =
+      '<?xml version="1.0"?>' +
+      '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">' +
+      '<Relationship Type="t" Target="x"/>' +
+      '<Relationship Id="rId7" Type="t" Target="x"/>' +
+      '</Relationships>'
+    const doc = new DOMParser().parseFromString(xml)
+    const rels = nodeListToArray(doc.getElementsByTagName('Relationship'))
+    // relsCount = 2, starts at 3, rId7 is taken but doesn't matter, returns 3
+    allocateFreshRid(rels).should.be.eql(3)
+  })
+})


### PR DESCRIPTION


https://github.com/capmo/capmo/pull/7193

fix(image): allocate non-colliding rIds when appending image relationships

## Summary

`docxImage` post-processing assigns each newly fetched image a relationship id of `rId${relsCount + 1}`. This collides with existing rIds whenever the source template's relationships are not densely numbered from 1 — which is almost every real-world template, because Word emits rIds with gaps (e.g.